### PR TITLE
Undo coordinate correction

### DIFF
--- a/py/CompareDistributions.py
+++ b/py/CompareDistributions.py
@@ -65,7 +65,10 @@ def main():
       ax.set_xlabel(label_dict[coord], ha='right', x=1.0)
       ax.set_ylabel(r"$d\sigma$ [fb$^{-1}$]", ha='right', y=1.0)
       
-      ax.legend(loc=0)
+      title = r"""$P_{{e^{{-}}}}=${0}
+$P_{{e^{{+}}}}=${1}""".format(eM_chirality,
+                                                                 eP_chirality)
+      ax.legend(loc=0, title=title)
       fig.savefig("{}/{}.pdf".format(output_path,coord))
       plt.close()
   

--- a/py/RKHelp/RKDistrMatcher.py
+++ b/py/RKHelp/RKDistrMatcher.py
@@ -25,8 +25,8 @@ class RKDistrMatcher:
   # Sometimes binning is different (without affecting the cross section)
   RK_bin_manipulator = {
     # Roberts WW distribution have a wrong Phi_l^* binning
-    "WW_semilep_MuAntiNu" : lambda x: np.array([x[0], -x[1], (x[2] - np.pi) * 9.0/10.0]),
-    "WW_semilep_AntiMuNu" : lambda x: np.array([x[0], -x[1], (x[2] - np.pi) * 9.0/10.0])
+    "WW_semilep_MuAntiNu" : lambda x: np.array([x[0], x[1], (x[2] - np.pi) * 9.0/10.0]),
+    "WW_semilep_AntiMuNu" : lambda x: np.array([x[0], x[1], (x[2] - np.pi) * 9.0/10.0])
   }
   
   def __init__(self, RK_distrs=None):


### PR DESCRIPTION
- Undo the artificial coordinate correction in the distribution matching for the WWs.
- Add ee chiralities in plot titles.